### PR TITLE
The text-aling center caused big changes in all the platform

### DIFF
--- a/edx-platform/edxapp-espol/lms/static/sass/_overrides.scss
+++ b/edx-platform/edxapp-espol/lms/static/sass/_overrides.scss
@@ -116,9 +116,10 @@ h1 {
   @extend .btn-default;
 }
 // password reset confirm
-.content-wrapper{
-  text-align: center;
-}
+// Removed by fmo, because the implications are too broad
+// .content-wrapper{
+  // text-align: center;
+// }
 // dashboard
 a, a:visited{
   color: $main-color;


### PR DESCRIPTION
@Icemberth I reverted this style because it was changing pages to have centered content all over the platform.

